### PR TITLE
refactor: migrate foundational styles to tailwind

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,66 @@
 @import "tailwindcss";
 
 @layer base {
-  body {
-    @apply text-gray-900 leading-relaxed;
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
   }
 
-  h1 {
-    @apply font-extrabold text-4xl md:text-5xl;
+  html {
+    font-family: var(--font-poppins), sans-serif;
   }
-  h2 {
-    @apply font-bold text-3xl md:text-4xl;
+
+  body {
+    background-color: #121212;
+    color: #fafafa;
+    line-height: 1.625;
   }
-  h3 {
-    @apply font-semibold text-2xl md:text-3xl;
+
+  a {
+    color: inherit;
+    text-decoration: none;
   }
-  h4 {
-    @apply font-semibold text-xl;
+
+  li {
+    list-style: none;
   }
-  h5 {
-    @apply font-medium text-lg;
+
+  img,
+  ion-icon,
+  a,
+  button,
+  time,
+  span {
+    display: block;
   }
-  h6 {
-    @apply font-medium text-base;
+
+  button {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+  }
+
+  input,
+  textarea {
+    background: none;
+    color: inherit;
+    display: block;
+    font: inherit;
+    width: 100%;
+  }
+
+  ::selection {
+    background-color: #2ecc71;
+    color: #121212;
+  }
+
+  :focus-visible {
+    outline-color: #2ecc71;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,11 +4,48 @@ import "./globals.css";
 import { generateStructuredData } from "@/lib/schemas/structured-data";
 import { seoData } from "@/lib/seo-data";
 import type { Metadata, Viewport } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Poppins } from "next/font/google";
 import type { JSX, ReactNode } from "react";
 import type { Thing, WithContext } from "schema-dts";
 
 export async function generateMetadata(): Promise<Metadata> {
+  const { performance } = seoData;
+  const preloadHints: string[] = [];
+
+  if (performance.fontPreload) {
+    preloadHints.push(
+      `<${performance.fontPreload}>; rel=preload; as=font; type=font/woff2; crossorigin`
+    );
+  }
+
+  preloadHints.push(
+    ...performance.resourceHints.preload.map(
+      (asset) => `<${asset}>; rel=preload; as=image`
+    )
+  );
+
+  const prefetchHints = performance.resourceHints.prefetch.map(
+    (asset) => `<${asset}>; rel=prefetch; as=image`
+  );
+
+  const other: Record<string, string> = {};
+
+  if (performance.dnsPrefetch) {
+    other["dns-prefetch"] = performance.dnsPrefetch;
+  }
+
+  if (performance.preconnect) {
+    other.preconnect = performance.preconnect;
+  }
+
+  if (preloadHints.length > 0) {
+    other.preload = preloadHints.join(", ");
+  }
+
+  if (prefetchHints.length > 0) {
+    other.prefetch = prefetchHints.join(", ");
+  }
+
   return {
     title: `${seoData.name} - ${seoData.jobTitle}`,
     description: seoData.description,
@@ -43,19 +80,7 @@ export async function generateMetadata(): Promise<Metadata> {
       images: [seoData.profileImage],
     },
     icons: [{ rel: "icon", url: "/favicon.ico" }],
-    other: {
-      "dns-prefetch": seoData.performance.dnsPrefetch,
-      preconnect: seoData.performance.preconnect,
-      preload: [
-        seoData.performance.fontPreload,
-        ...seoData.performance.resourceHints.preload.map(
-          (asset) => `<${asset}>; rel=preload; as=image`
-        ),
-      ].join(", "),
-      prefetch: seoData.performance.resourceHints.prefetch
-        .map((asset) => `<${asset}>; rel=prefetch; as=image`)
-        .join(", "),
-    },
+    other: Object.keys(other).length > 0 ? other : undefined,
   };
 }
 
@@ -72,6 +97,13 @@ const inter = Inter({
   display: "swap",
 });
 
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
+  variable: "--font-poppins",
+  display: "swap",
+});
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -80,7 +112,11 @@ export default function RootLayout({
   const schemas: WithContext<Thing>[] = generateStructuredData();
 
   return (
-    <html lang="en" className={inter.variable} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${inter.variable} ${poppins.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         {schemas.map((schema, index) => (
           <script
@@ -90,7 +126,9 @@ export default function RootLayout({
           />
         ))}
       </head>
-      <body className="antialiased font-sans">{children}</body>
+      <body className="antialiased bg-smoky-black text-white-2 font-poppins">
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/lib/seo-data.ts
+++ b/src/lib/seo-data.ts
@@ -29,9 +29,9 @@ export const seoData: SEOData = {
       p.categories.includes("AI Features") || p.categories.includes("Web App")
   ),
   performance: {
-    dnsPrefetch: "https://fonts.googleapis.com",
-    preconnect: "https://fonts.gstatic.com",
-    fontPreload: "/fonts/inter-var.woff2",
+    dnsPrefetch: "",
+    preconnect: "",
+    fontPreload: "",
     criticalAssets: {
       profileImage: personalInfo.avatarPath,
       companyLogo: "/assets/images/iohub-logo.webp",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,6 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap");
 @import url("variables.css");
-@import url("reset.css");
 @import url("layout.css");
 @import url("components.css");
 @import url("sections.css");

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,49 +9,31 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        xs: "450px",
+        sm: "580px",
+        md: "768px",
+        lg: "1024px",
+        xl: "1250px",
+      },
       fontFamily: {
-        sans: ["var(--font-inter)", "Roboto", "sans-serif"],
+        sans: ["var(--font-poppins)", "sans-serif"],
+        poppins: ["var(--font-poppins)", "sans-serif"],
+        inter: ["var(--font-inter)", "sans-serif"],
       },
       colors: {
-        //? Primary brand colors
-        primary: "#0070f3",
-        secondary: "#ff4081",
-        accent: "#f5a623",
-
-        //? Status colors
-        success: "#4caf50",
-        warning: "#ffc107",
-        error: "#f44336",
-
-        //? Neutral grays
-        "light-gray": "#f6f6f6",
-        "dark-gray": "#333333",
-
-        //? Custom portfolio colors
-        onyx: "#2b2b2b",
         jet: "#383838",
+        onyx: "#2b2b2b",
         "eerie-black-1": "#212121",
         "eerie-black-2": "#1f1f1f",
         "smoky-black": "#121212",
         "white-1": "#ffffff",
         "white-2": "#fafafa",
-
-        //? Accent colors
-        highlight: "#2ecc71", //? Main highlight color
-        "highlight-50": "#e8f8f0",
-        "highlight-100": "#d1f2e1",
-        "highlight-200": "#a3e5c3",
-        "highlight-300": "#75d8a5",
-        "highlight-400": "#47cb87",
-        "highlight-500": "#2ecc71", //? Main highlight
-        "highlight-600": "#25a35a",
-        "highlight-700": "#1c7a43",
-        "highlight-800": "#13512c",
-        "highlight-900": "#0a2815",
-        "light-gray-70": "#d6d6d6",
+        highlight: "#2ecc71",
+        "highlight-dark": "#25a35a",
+        "light-gray": "#d6d6d6",
+        "light-gray-70": "rgba(214, 214, 214, 0.7)",
         "bittersweet-shimmer": "#d63384",
-
-        //? Transparent colors for overlays and shadows
         "black-10": "rgba(0, 0, 0, 0.1)",
         "black-15": "rgba(0, 0, 0, 0.15)",
         "black-25": "rgba(0, 0, 0, 0.25)",
@@ -60,14 +42,33 @@ const config: Config = {
         "white-10": "rgba(255, 255, 255, 0.1)",
         "white-11": "rgba(255, 255, 255, 0.11)",
         "white-15": "rgba(255, 255, 255, 0.15)",
-
-        //? Dark text color from globals.css
-        "text-dark": "rgb(17, 24, 39)",
       },
       backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        "gradient-onyx": "linear-gradient(to bottom right, #404040 3%, #303030 97%)",
+        "gradient-jet":
+          "linear-gradient(135deg, rgba(43,43,43,0.251) 0%, rgba(28,28,28,0) 100%), #212121",
+        "gradient-highlight-1":
+          "linear-gradient(135deg, #2ecc71 0%, rgba(46,204,113,0) 50%)",
+        "gradient-highlight-2":
+          "linear-gradient(135deg, rgba(46,204,113,0.251) 0%, rgba(46,204,113,0) 59.86%), #212121",
+        "border-gradient-onyx":
+          "linear-gradient(to bottom right, #404040 0%, rgba(64, 64, 64, 0) 50%)",
+        "text-gradient-highlight": "linear-gradient(to right, #2ecc71, #25a35a)",
+      },
+      boxShadow: {
+        1: "-4px 8px 24px rgba(0, 0, 0, 0.25)",
+        2: "0 16px 30px rgba(0, 0, 0, 0.25)",
+        3: "0 16px 40px rgba(0, 0, 0, 0.25)",
+        4: "0 25px 50px rgba(0, 0, 0, 0.15)",
+        5: "0 24px 80px rgba(0, 0, 0, 0.25)",
+      },
+      transitionDuration: {
+        250: "250ms",
+        500: "500ms",
+      },
+      transitionTimingFunction: {
+        standard: "ease",
+        "in-out": "ease-in-out",
       },
     },
   },


### PR DESCRIPTION
## Summary
- map the legacy CSS variables to Tailwind theme extensions including screens, gradients, and box shadows
- switch the global font pipeline to `next/font` (Poppins + Inter) and streamline metadata resource hints
- relocate reset behaviors into the Tailwind base layer and drop the standalone reset import from the legacy bundle

## Testing
- `yarn check` *(fails: Yarn 4 in the container requests a lockfile update)*

------
https://chatgpt.com/codex/tasks/task_e_68e1dc0b05888323af89f9537d5929f2